### PR TITLE
Add PDF export of summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,6 +130,7 @@ class CostCalculator {
 
         document.getElementById('saveBtn').addEventListener('click', () => {
             this.saveToStorage();
+            this.exportPDF();
         });
 
         document.getElementById('loadBtn').addEventListener('click', () => {
@@ -532,6 +533,23 @@ class CostCalculator {
             this.showMessage('Eroare la încărcarea estimării!', 'error');
             console.error('Error loading estimation:', error);
         }
+    }
+
+    exportPDF() {
+        const element = document.getElementById('summarySection');
+        if (!element) {
+            this.showMessage('Secțiunea de sumar nu a fost găsită!', 'error');
+            return;
+        }
+
+        const opt = {
+            margin:       10,
+            filename:     'estimare_costuri.pdf',
+            html2canvas:  { scale: 2 },
+            jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
+        };
+
+        html2pdf().set(opt).from(element).save();
     }
 
     resetCalculator() {

--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@
             </section>
 
             <!-- Results Summary -->
-            <section class="card mb-16">
+            <section class="card mb-16" id="summarySection">
                 <div class="card__header">
                     <h2>Sumar Costuri</h2>
                 </div>
@@ -317,6 +317,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- include html2pdf.js in the page
- tag the summary section for export
- implement `exportPDF()` and call it from Save button

## Testing
- `python deploy.py` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68412b0786708320a64be3e390963838