### PR TITLE
Add configuration panel for rates

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,31 +1,152 @@
 // Cost Estimation Calculator JavaScript
 
+const defaultConfig = {
+    rates: {
+        junior: 42,
+        mid: 65,
+        senior: 95,
+        architect: 85,
+        qaManual: 35,
+        qaAuto: 45,
+        documentation: 40,
+        training: 40,
+        projectMgmt: 75
+    },
+    hardwareCosts: {
+        assembly: 1500,
+        certification: 6000,
+        logistics: 800
+    },
+    licensePresets: {
+        database: { name: 'Licență Bază de Date Enterprise', cost: 5000 },
+        framework: { name: 'Framework Comercial', cost: 2500 },
+        cicd: { name: 'Instrumente CI/CD', cost: 1000 },
+        ide: { name: 'IDE Professional', cost: 500 }
+    },
+    riskBuffer: 15,
+    commercialMargin: 20
+};
+
+function loadConfig() {
+    try {
+        const raw = localStorage.getItem('costConfig');
+        if (raw) {
+            return JSON.parse(raw);
+        }
+    } catch (e) {
+        console.error('Failed to load config', e);
+    }
+    return JSON.parse(JSON.stringify(defaultConfig));
+}
+
+function saveConfig(cfg) {
+    try {
+        localStorage.setItem('costConfig', JSON.stringify(cfg));
+    } catch (e) {
+        console.error('Failed to save config', e);
+    }
+}
+
 class CostCalculator {
     constructor() {
-        this.rates = {
-            junior: 42,
-            mid: 65,
-            senior: 95,
-            architect: 85,
-            qaManual: 35,
-            qaAuto: 45,
-            documentation: 40,
-            training: 40,
-            projectMgmt: 75
-        };
-
-        this.licensePresets = {
-            database: { name: 'Licență Bază de Date Enterprise', cost: 5000 },
-            framework: { name: 'Framework Comercial', cost: 2500 },
-            cicd: { name: 'Instrumente CI/CD', cost: 1000 },
-            ide: { name: 'IDE Professional', cost: 500 }
-        };
-
+        this.config = loadConfig();
+        this.rates = { ...this.config.rates };
+        this.hardwareCosts = { ...this.config.hardwareCosts };
+        this.licensePresets = JSON.parse(JSON.stringify(this.config.licensePresets));
         this.chart = null;
         this.init();
     }
 
+    applyConfigToUI() {
+        // Developer rates display
+        document.getElementById('rateJuniorDisplay').textContent = `${this.rates.junior} €/oră`;
+        document.getElementById('rateMidDisplay').textContent = `${this.rates.mid} €/oră`;
+        document.getElementById('rateSeniorDisplay').textContent = `${this.rates.senior} €/oră`;
+        document.getElementById('rateArchitectDisplay').textContent = `${this.rates.architect} €/oră`;
+
+        // Service labels
+        document.getElementById('labelQaManual').textContent = `Testare QA Manual (${this.rates.qaManual} €/oră)`;
+        document.getElementById('labelQaAuto').textContent = `Testare QA Automatizat (${this.rates.qaAuto} €/oră)`;
+        document.getElementById('labelDocumentation').textContent = `Documentație Tehnică (${this.rates.documentation} €/oră)`;
+        document.getElementById('labelTraining').textContent = `Training Utilizatori (${this.rates.training} €/oră)`;
+        document.getElementById('labelProjectMgmt').textContent = `Management Proiect (${this.rates.projectMgmt} €/oră)`;
+
+        // Hardware service labels and placeholders
+        document.getElementById('labelAssembly').textContent = 'Asamblare și Testare';
+        document.getElementById('labelCertification').textContent = 'Certificări (CE, FCC, ROHS)';
+        document.getElementById('labelLogistics').textContent = 'Logistică și Transport';
+        document.getElementById('assemblyCost').placeholder = this.hardwareCosts.assembly;
+        document.getElementById('certificationCost').placeholder = this.hardwareCosts.certification;
+        document.getElementById('logisticsCost').placeholder = this.hardwareCosts.logistics;
+
+        // License option texts
+        const setOption = (id, obj) => {
+            const el = document.getElementById(id);
+            if (el) el.textContent = `${obj.name} (${obj.cost} €)`;
+        };
+        setOption('optDatabase', this.licensePresets.database);
+        setOption('optFramework', this.licensePresets.framework);
+        setOption('optCicd', this.licensePresets.cicd);
+        setOption('optIde', this.licensePresets.ide);
+
+        // Sliders default values
+        document.getElementById('riskBuffer').value = this.config.riskBuffer;
+        document.getElementById('commercialMargin').value = this.config.commercialMargin;
+        document.getElementById('riskValue').textContent = this.config.riskBuffer;
+        document.getElementById('marginValue').textContent = this.config.commercialMargin;
+
+        // Config form values
+        document.getElementById('cfgJunior').value = this.rates.junior;
+        document.getElementById('cfgMid').value = this.rates.mid;
+        document.getElementById('cfgSenior').value = this.rates.senior;
+        document.getElementById('cfgArchitect').value = this.rates.architect;
+        document.getElementById('cfgQaManual').value = this.rates.qaManual;
+        document.getElementById('cfgQaAuto').value = this.rates.qaAuto;
+        document.getElementById('cfgDocumentation').value = this.rates.documentation;
+        document.getElementById('cfgTraining').value = this.rates.training;
+        document.getElementById('cfgProjectMgmt').value = this.rates.projectMgmt;
+        document.getElementById('cfgAssembly').value = this.hardwareCosts.assembly;
+        document.getElementById('cfgCertification').value = this.hardwareCosts.certification;
+        document.getElementById('cfgLogistics').value = this.hardwareCosts.logistics;
+        document.getElementById('cfgLicDbName').value = this.licensePresets.database.name;
+        document.getElementById('cfgLicDbCost').value = this.licensePresets.database.cost;
+        document.getElementById('cfgLicFwName').value = this.licensePresets.framework.name;
+        document.getElementById('cfgLicFwCost').value = this.licensePresets.framework.cost;
+        document.getElementById('cfgLicCiName').value = this.licensePresets.cicd.name;
+        document.getElementById('cfgLicCiCost').value = this.licensePresets.cicd.cost;
+        document.getElementById('cfgLicIdeName').value = this.licensePresets.ide.name;
+        document.getElementById('cfgLicIdeCost').value = this.licensePresets.ide.cost;
+    }
+
+    updateConfigFromForm() {
+        this.config.rates.junior = parseFloat(document.getElementById('cfgJunior').value) || 0;
+        this.config.rates.mid = parseFloat(document.getElementById('cfgMid').value) || 0;
+        this.config.rates.senior = parseFloat(document.getElementById('cfgSenior').value) || 0;
+        this.config.rates.architect = parseFloat(document.getElementById('cfgArchitect').value) || 0;
+        this.config.rates.qaManual = parseFloat(document.getElementById('cfgQaManual').value) || 0;
+        this.config.rates.qaAuto = parseFloat(document.getElementById('cfgQaAuto').value) || 0;
+        this.config.rates.documentation = parseFloat(document.getElementById('cfgDocumentation').value) || 0;
+        this.config.rates.training = parseFloat(document.getElementById('cfgTraining').value) || 0;
+        this.config.rates.projectMgmt = parseFloat(document.getElementById('cfgProjectMgmt').value) || 0;
+        this.config.hardwareCosts.assembly = parseFloat(document.getElementById('cfgAssembly').value) || 0;
+        this.config.hardwareCosts.certification = parseFloat(document.getElementById('cfgCertification').value) || 0;
+        this.config.hardwareCosts.logistics = parseFloat(document.getElementById('cfgLogistics').value) || 0;
+        this.config.licensePresets.database.name = document.getElementById('cfgLicDbName').value || '';
+        this.config.licensePresets.database.cost = parseFloat(document.getElementById('cfgLicDbCost').value) || 0;
+        this.config.licensePresets.framework.name = document.getElementById('cfgLicFwName').value || '';
+        this.config.licensePresets.framework.cost = parseFloat(document.getElementById('cfgLicFwCost').value) || 0;
+        this.config.licensePresets.cicd.name = document.getElementById('cfgLicCiName').value || '';
+        this.config.licensePresets.cicd.cost = parseFloat(document.getElementById('cfgLicCiCost').value) || 0;
+        this.config.licensePresets.ide.name = document.getElementById('cfgLicIdeName').value || '';
+        this.config.licensePresets.ide.cost = parseFloat(document.getElementById('cfgLicIdeCost').value) || 0;
+
+        this.rates = { ...this.config.rates };
+        this.hardwareCosts = { ...this.config.hardwareCosts };
+        this.licensePresets = JSON.parse(JSON.stringify(this.config.licensePresets));
+    }
+
     init() {
+        this.applyConfigToUI();
         this.bindEvents();
         this.initChart();
         this.updateVisibility();
@@ -81,10 +202,7 @@ class CostCalculator {
             checkbox.addEventListener('change', () => {
                 costInput.disabled = !checkbox.checked;
                 if (checkbox.checked && costInput.value === '') {
-                    // Set default values when checkbox is checked
-                    if (service === 'assembly') costInput.value = 1500;
-                    if (service === 'certification') costInput.value = 6000;
-                    if (service === 'logistics') costInput.value = 800;
+                    costInput.value = this.hardwareCosts[service];
                 }
                 this.calculateHardwareServices();
                 this.calculateAll();
@@ -112,6 +230,8 @@ class CostCalculator {
         
         riskSlider.addEventListener('input', () => {
             riskValue.textContent = riskSlider.value;
+            this.config.riskBuffer = parseInt(riskSlider.value);
+            saveConfig(this.config);
             this.calculateAll();
         });
 
@@ -120,6 +240,8 @@ class CostCalculator {
         
         marginSlider.addEventListener('input', () => {
             marginValue.textContent = marginSlider.value;
+            this.config.commercialMargin = parseInt(marginSlider.value);
+            saveConfig(this.config);
             this.calculateAll();
         });
 
@@ -134,6 +256,23 @@ class CostCalculator {
 
         document.getElementById('loadBtn').addEventListener('click', () => {
             this.loadFromStorage();
+        });
+
+        document.getElementById('navConfig').addEventListener('click', () => {
+            document.getElementById('calculatorView').style.display = 'none';
+            document.getElementById('configSection').style.display = 'block';
+        });
+
+        document.getElementById('navCalculator').addEventListener('click', () => {
+            document.getElementById('calculatorView').style.display = 'block';
+            document.getElementById('configSection').style.display = 'none';
+        });
+
+        document.getElementById('saveConfigBtn').addEventListener('click', () => {
+            this.updateConfigFromForm();
+            saveConfig(this.config);
+            this.applyConfigToUI();
+            this.calculateAll();
         });
 
         // Initial license row setup
@@ -356,10 +495,10 @@ class CostCalculator {
         newRow.innerHTML = `
             <select class="form-control license-select">
                 <option value="">Selectează licența...</option>
-                <option value="database">Licență Bază de Date Enterprise (5000 €)</option>
-                <option value="framework">Framework Comercial (2500 €)</option>
-                <option value="cicd">Instrumente CI/CD (1000 €)</option>
-                <option value="ide">IDE Professional (500 €)</option>
+                <option value="database">${this.licensePresets.database.name} (${this.licensePresets.database.cost} €)</option>
+                <option value="framework">${this.licensePresets.framework.name} (${this.licensePresets.framework.cost} €)</option>
+                <option value="cicd">${this.licensePresets.cicd.name} (${this.licensePresets.cicd.cost} €)</option>
+                <option value="ide">${this.licensePresets.ide.name} (${this.licensePresets.ide.cost} €)</option>
                 <option value="custom">Personalizată</option>
             </select>
             <input type="text" class="form-control license-name" placeholder="Numele licenței" style="display: none;">
@@ -551,10 +690,10 @@ class CostCalculator {
             });
 
             // Reset sliders to defaults
-            document.getElementById('riskBuffer').value = 15;
-            document.getElementById('commercialMargin').value = 20;
-            document.getElementById('riskValue').textContent = '15';
-            document.getElementById('marginValue').textContent = '20';
+            document.getElementById('riskBuffer').value = this.config.riskBuffer;
+            document.getElementById('commercialMargin').value = this.config.commercialMargin;
+            document.getElementById('riskValue').textContent = this.config.riskBuffer;
+            document.getElementById('marginValue').textContent = this.config.commercialMargin;
 
             // Reset project type
             document.getElementById('projectType').value = 'software';
@@ -583,6 +722,7 @@ class CostCalculator {
             document.querySelector('.component-name').value = '';
             document.querySelector('.component-price').value = '';
 
+            this.applyConfigToUI();
             this.updateVisibility();
             this.calculateAll();
             this.showMessage('Calculatorul a fost resetat!', 'info');

--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
         </header>
 
         <main>
+            <nav class="flex gap-16 justify-center mb-16">
+                <button type="button" id="navCalculator" class="btn btn--outline">Calculator</button>
+                <button type="button" id="navConfig" class="btn btn--outline">Config</button>
+            </nav>
+            <div id="calculatorView">
             <!-- Project Information Section -->
             <section class="card mb-16">
                 <div class="card__header">
@@ -59,7 +64,7 @@
                     <div class="dev-roles-grid">
                         <div class="role-card">
                             <h4>Developer Junior</h4>
-                            <p class="rate-display">42 €/oră</p>
+                            <p class="rate-display" id="rateJuniorDisplay"></p>
                             <div class="form-group">
                                 <label for="juniorHours" class="form-label">Ore estimate</label>
                                 <input type="number" id="juniorHours" class="form-control" min="0" value="0">
@@ -72,7 +77,7 @@
                         
                         <div class="role-card">
                             <h4>Developer Mid</h4>
-                            <p class="rate-display">65 €/oră</p>
+                            <p class="rate-display" id="rateMidDisplay"></p>
                             <div class="form-group">
                                 <label for="midHours" class="form-label">Ore estimate</label>
                                 <input type="number" id="midHours" class="form-control" min="0" value="0">
@@ -85,7 +90,7 @@
                         
                         <div class="role-card">
                             <h4>Developer Senior</h4>
-                            <p class="rate-display">95 €/oră</p>
+                            <p class="rate-display" id="rateSeniorDisplay"></p>
                             <div class="form-group">
                                 <label for="seniorHours" class="form-label">Ore estimate</label>
                                 <input type="number" id="seniorHours" class="form-control" min="0" value="0">
@@ -98,7 +103,7 @@
                         
                         <div class="role-card">
                             <h4>Arhitect Software</h4>
-                            <p class="rate-display">85 €/oră</p>
+                            <p class="rate-display" id="rateArchitectDisplay"></p>
                             <div class="form-group">
                                 <label for="architectHours" class="form-label">Ore estimate</label>
                                 <input type="number" id="architectHours" class="form-control" min="0" value="0">
@@ -115,7 +120,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="qaManual" class="service-checkbox">
-                                <label for="qaManual" class="service-label">Testare QA Manual (35 €/oră)</label>
+                                <label for="qaManual" class="service-label" id="labelQaManual"></label>
                             </div>
                             <input type="number" id="qaManualHours" class="form-control service-hours" placeholder="200" disabled>
                             <span class="service-cost" id="qaManualCost">0 €</span>
@@ -124,7 +129,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="qaAuto" class="service-checkbox">
-                                <label for="qaAuto" class="service-label">Testare QA Automatizat (45 €/oră)</label>
+                                <label for="qaAuto" class="service-label" id="labelQaAuto"></label>
                             </div>
                             <input type="number" id="qaAutoHours" class="form-control service-hours" placeholder="100" disabled>
                             <span class="service-cost" id="qaAutoCost">0 €</span>
@@ -133,7 +138,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="documentation" class="service-checkbox">
-                                <label for="documentation" class="service-label">Documentație Tehnică (40 €/oră)</label>
+                                <label for="documentation" class="service-label" id="labelDocumentation"></label>
                             </div>
                             <input type="number" id="documentationHours" class="form-control service-hours" placeholder="80" disabled>
                             <span class="service-cost" id="documentationCost">0 €</span>
@@ -142,7 +147,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="training" class="service-checkbox">
-                                <label for="training" class="service-label">Training Utilizatori (40 €/oră)</label>
+                                <label for="training" class="service-label" id="labelTraining"></label>
                             </div>
                             <input type="number" id="trainingHours" class="form-control service-hours" placeholder="40" disabled>
                             <span class="service-cost" id="trainingCost">0 €</span>
@@ -151,7 +156,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="projectMgmt" class="service-checkbox">
-                                <label for="projectMgmt" class="service-label">Management Proiect (75 €/oră)</label>
+                                <label for="projectMgmt" class="service-label" id="labelProjectMgmt"></label>
                             </div>
                             <input type="number" id="projectMgmtHours" class="form-control service-hours" placeholder="160" disabled>
                             <span class="service-cost" id="projectMgmtCost">0 €</span>
@@ -163,10 +168,10 @@
                         <div class="license-item">
                             <select class="form-control license-select">
                                 <option value="">Selectează licența...</option>
-                                <option value="database">Licență Bază de Date Enterprise (5000 €)</option>
-                                <option value="framework">Framework Comercial (2500 €)</option>
-                                <option value="cicd">Instrumente CI/CD (1000 €)</option>
-                                <option value="ide">IDE Professional (500 €)</option>
+                                <option value="database" id="optDatabase"></option>
+                                <option value="framework" id="optFramework"></option>
+                                <option value="cicd" id="optCicd"></option>
+                                <option value="ide" id="optIde"></option>
                                 <option value="custom">Personalizată</option>
                             </select>
                             <input type="text" class="form-control license-name" placeholder="Numele licenței" style="display: none;">
@@ -207,7 +212,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="assembly" class="hw-service-checkbox">
-                                <label for="assembly" class="service-label">Asamblare și Testare</label>
+                                <label for="assembly" class="service-label" id="labelAssembly"></label>
                             </div>
                             <input type="number" id="assemblyCost" class="form-control service-cost-input" placeholder="1500" disabled>
                             <span class="service-cost" id="assemblyTotal">0 €</span>
@@ -216,7 +221,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="certification" class="hw-service-checkbox">
-                                <label for="certification" class="service-label">Certificări (CE, FCC, ROHS)</label>
+                                <label for="certification" class="service-label" id="labelCertification"></label>
                             </div>
                             <input type="number" id="certificationCost" class="form-control service-cost-input" placeholder="6000" disabled>
                             <span class="service-cost" id="certificationTotal">0 €</span>
@@ -225,7 +230,7 @@
                         <div class="service-item">
                             <div class="flex items-center gap-8">
                                 <input type="checkbox" id="logistics" class="hw-service-checkbox">
-                                <label for="logistics" class="service-label">Logistică și Transport</label>
+                                <label for="logistics" class="service-label" id="labelLogistics"></label>
                             </div>
                             <input type="number" id="logisticsCost" class="form-control service-cost-input" placeholder="800" disabled>
                             <span class="service-cost" id="logisticsTotal">0 €</span>
@@ -246,8 +251,8 @@
                 <div class="card__body">
                     <div class="slider-grid">
                         <div class="slider-group">
-                            <label for="riskBuffer" class="form-label">Buffer Risc: <span id="riskValue">15</span>%</label>
-                            <input type="range" id="riskBuffer" min="10" max="25" value="15" class="slider">
+                            <label for="riskBuffer" class="form-label">Buffer Risc: <span id="riskValue"></span>%</label>
+                            <input type="range" id="riskBuffer" min="10" max="25" value="0" class="slider">
                             <div class="slider-info">
                                 <span>10%</span>
                                 <span>25%</span>
@@ -255,8 +260,8 @@
                         </div>
                         
                         <div class="slider-group">
-                            <label for="commercialMargin" class="form-label">Marjă Comercială: <span id="marginValue">20</span>%</label>
-                            <input type="range" id="commercialMargin" min="15" max="30" value="20" class="slider">
+                            <label for="commercialMargin" class="form-label">Marjă Comercială: <span id="marginValue"></span>%</label>
+                            <input type="range" id="commercialMargin" min="15" max="30" value="0" class="slider">
                             <div class="slider-info">
                                 <span>15%</span>
                                 <span>30%</span>
@@ -311,6 +316,106 @@
                     <button type="button" id="resetBtn" class="btn btn--secondary">Resetează</button>
                     <button type="button" id="saveBtn" class="btn btn--primary">Salvează Estimarea</button>
                     <button type="button" id="loadBtn" class="btn btn--outline">Încarcă Estimarea</button>
+                </div>
+            </section>
+            </div>
+
+            <section class="card mb-16" id="configSection" style="display: none;">
+                <div class="card__header">
+                    <h2>Configurare Tarife și Preseturi</h2>
+                </div>
+                <div class="card__body">
+                    <h3 class="mb-8">Tarife Dezvoltatori</h3>
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label for="cfgJunior" class="form-label">Junior €/oră</label>
+                            <input type="number" id="cfgJunior" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgMid" class="form-label">Mid €/oră</label>
+                            <input type="number" id="cfgMid" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgSenior" class="form-label">Senior €/oră</label>
+                            <input type="number" id="cfgSenior" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgArchitect" class="form-label">Arhitect €/oră</label>
+                            <input type="number" id="cfgArchitect" class="form-control" min="0">
+                        </div>
+                    </div>
+
+                    <h3 class="mb-8 mt-24">Tarife Servicii</h3>
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label for="cfgQaManual" class="form-label">QA Manual €/oră</label>
+                            <input type="number" id="cfgQaManual" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgQaAuto" class="form-label">QA Automat €/oră</label>
+                            <input type="number" id="cfgQaAuto" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgDocumentation" class="form-label">Documentație €/oră</label>
+                            <input type="number" id="cfgDocumentation" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgTraining" class="form-label">Training €/oră</label>
+                            <input type="number" id="cfgTraining" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgProjectMgmt" class="form-label">Management Proiect €/oră</label>
+                            <input type="number" id="cfgProjectMgmt" class="form-control" min="0">
+                        </div>
+                    </div>
+
+                    <h3 class="mb-8 mt-24">Costuri Servicii Hardware</h3>
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label for="cfgAssembly" class="form-label">Asamblare €</label>
+                            <input type="number" id="cfgAssembly" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgCertification" class="form-label">Certificări €</label>
+                            <input type="number" id="cfgCertification" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgLogistics" class="form-label">Logistică €</label>
+                            <input type="number" id="cfgLogistics" class="form-control" min="0">
+                        </div>
+                    </div>
+
+                    <h3 class="mb-8 mt-24">Preseturi Licențe</h3>
+                    <div class="form-grid">
+                        <div class="form-group">
+                            <label for="cfgLicDbName" class="form-label">Bază de Date - Nume</label>
+                            <input type="text" id="cfgLicDbName" class="form-control">
+                            <label for="cfgLicDbCost" class="form-label mt-4">Cost (€)</label>
+                            <input type="number" id="cfgLicDbCost" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgLicFwName" class="form-label">Framework - Nume</label>
+                            <input type="text" id="cfgLicFwName" class="form-control">
+                            <label for="cfgLicFwCost" class="form-label mt-4">Cost (€)</label>
+                            <input type="number" id="cfgLicFwCost" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgLicCiName" class="form-label">CI/CD - Nume</label>
+                            <input type="text" id="cfgLicCiName" class="form-control">
+                            <label for="cfgLicCiCost" class="form-label mt-4">Cost (€)</label>
+                            <input type="number" id="cfgLicCiCost" class="form-control" min="0">
+                        </div>
+                        <div class="form-group">
+                            <label for="cfgLicIdeName" class="form-label">IDE - Nume</label>
+                            <input type="text" id="cfgLicIdeName" class="form-control">
+                            <label for="cfgLicIdeCost" class="form-label mt-4">Cost (€)</label>
+                            <input type="number" id="cfgLicIdeCost" class="form-control" min="0">
+                        </div>
+                    </div>
+
+                    <div class="mt-24 flex justify-center">
+                        <button type="button" id="saveConfigBtn" class="btn btn--primary">Salvează Config</button>
+                    </div>
                 </div>
             </section>
         </main>


### PR DESCRIPTION
## Summary
- add Config section in HTML with form inputs for developer, service and hardware rates
- insert navigation buttons for calculator and configuration views
- populate UI elements with rates and defaults from a new configuration object
- persist configuration in localStorage
- update calculator logic to use the saved configuration

## Testing
- `node --check app.js`
- `python -m py_compile deploy.py`

------
https://chatgpt.com/codex/tasks/task_e_68412afd91a48320b0709030e66c0e3b