### PR TITLE
Dynamic license presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,14 +166,7 @@
                     <h3 class="mb-16 mt-24">Licențe Software</h3>
                     <div id="licensesContainer">
                         <div class="license-item">
-                            <select class="form-control license-select">
-                                <option value="">Selectează licența...</option>
-                                <option value="database" id="optDatabase"></option>
-                                <option value="framework" id="optFramework"></option>
-                                <option value="cicd" id="optCicd"></option>
-                                <option value="ide" id="optIde"></option>
-                                <option value="custom">Personalizată</option>
-                            </select>
+                            <select class="form-control license-select"></select>
                             <input type="text" class="form-control license-name" placeholder="Numele licenței" style="display: none;">
                             <input type="number" class="form-control license-quantity" placeholder="Cantitate" min="1" value="1">
                             <input type="number" class="form-control license-cost" placeholder="Cost unitar" min="0">
@@ -386,32 +379,8 @@
                     </div>
 
                     <h3 class="mb-8 mt-24">Preseturi Licențe</h3>
-                    <div class="form-grid">
-                        <div class="form-group">
-                            <label for="cfgLicDbName" class="form-label">Bază de Date - Nume</label>
-                            <input type="text" id="cfgLicDbName" class="form-control">
-                            <label for="cfgLicDbCost" class="form-label mt-4">Cost (€)</label>
-                            <input type="number" id="cfgLicDbCost" class="form-control" min="0">
-                        </div>
-                        <div class="form-group">
-                            <label for="cfgLicFwName" class="form-label">Framework - Nume</label>
-                            <input type="text" id="cfgLicFwName" class="form-control">
-                            <label for="cfgLicFwCost" class="form-label mt-4">Cost (€)</label>
-                            <input type="number" id="cfgLicFwCost" class="form-control" min="0">
-                        </div>
-                        <div class="form-group">
-                            <label for="cfgLicCiName" class="form-label">CI/CD - Nume</label>
-                            <input type="text" id="cfgLicCiName" class="form-control">
-                            <label for="cfgLicCiCost" class="form-label mt-4">Cost (€)</label>
-                            <input type="number" id="cfgLicCiCost" class="form-control" min="0">
-                        </div>
-                        <div class="form-group">
-                            <label for="cfgLicIdeName" class="form-label">IDE - Nume</label>
-                            <input type="text" id="cfgLicIdeName" class="form-control">
-                            <label for="cfgLicIdeCost" class="form-label mt-4">Cost (€)</label>
-                            <input type="number" id="cfgLicIdeCost" class="form-control" min="0">
-                        </div>
-                    </div>
+                    <div id="licensePresetsConfig"></div>
+                    <button type="button" id="addPresetBtn" class="btn btn--outline btn--sm mt-8">+ Adaugă Preset</button>
 
                     <div class="mt-24 flex justify-center">
                         <button type="button" id="saveConfigBtn" class="btn btn--primary">Salvează Config</button>

--- a/style.css
+++ b/style.css
@@ -859,6 +859,32 @@ select.form-control {
   text-align: right;
 }
 
+/* License Presets Config */
+#licensePresetsConfig {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.preset-row {
+  display: grid;
+  grid-template-columns: 1fr 2fr auto auto;
+  gap: var(--space-12);
+  align-items: center;
+}
+
+.preset-id,
+.preset-name,
+.preset-cost {
+  font-size: var(--font-size-sm);
+  padding: var(--space-6) var(--space-8);
+}
+
+.remove-preset {
+  font-size: var(--font-size-xs);
+  padding: var(--space-4) var(--space-8);
+}
+
 /* Totals Display */
 .software-total,
 .hardware-total {


### PR DESCRIPTION
## Summary
- move license presets to array of objects with id, name and cost
- generate license preset rows dynamically in the config panel
- update license dropdowns using the new preset array
- allow adding/removing preset rows
- style the new preset management section

## Testing
- `node --check app.js`
- `python -m py_compile deploy.py`


------
https://chatgpt.com/codex/tasks/task_e_6841314b92a083208ad7043aef0174ef