### PR TITLE
Fix PDF export with off-screen clone

### DIFF
--- a/app.js
+++ b/app.js
@@ -743,7 +743,13 @@ class CostCalculator {
                 jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
             };
 
-            html2pdf().set(opt).from(clone).save();
+            clone.style.position = 'fixed';
+            clone.style.left = '-9999px';
+            document.body.appendChild(clone);
+
+            html2pdf().set(opt).from(clone).save().then(() => {
+                document.body.removeChild(clone);
+            });
         }, 300);
     }
 


### PR DESCRIPTION
## Summary
- properly mount a hidden copy of the summary section for html2pdf
- remove the cloned node after saving

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684134c285ac832091baa82be0135253