### PR TITLE
Replace custom font with Inter for PDF

### DIFF
--- a/app.js
+++ b/app.js
@@ -739,7 +739,7 @@ class CostCalculator {
             const opt = {
                 margin:       10,
                 filename:     'estimare_costuri.pdf',
-                html2canvas:  { scale: 2 },
+                html2canvas:  { scale: 2, useCORS: true },
                 jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
             };
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calculator Estimare Costuri IT</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -37,8 +37,8 @@
   --color-info-rgb: 98, 108, 113;
 
   /* Typography */
-  --font-family-base: "FKGroteskNeue", "Geist", "Inter", -apple-system,
-    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-family-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, sans-serif;
   --font-family-mono: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo,
     Monaco, Consolas, monospace;
   --font-size-xs: 11px;
@@ -648,11 +648,6 @@ select.form-control {
   border: 1px solid var(--color-border-secondary);
 }
 
-@font-face {
-  font-family: 'FKGroteskNeue';
-  src: url('https://www.perplexity.ai/fonts/FKGroteskNeue.woff2')
-    format('woff2');
-}
 
 /* Additional styles for the Cost Estimation Calculator */
 


### PR DESCRIPTION
## Summary
- switch base font to Inter
- remove custom font face
- load Inter font from Google Fonts
- set `useCORS: true` for html2canvas in PDF generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68413f321c588320bd7dcdbdfecce88d