### PR TITLE
Add .env example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for local development
+SECRET_KEY=
+GEMINI_API_KEY=
+NGROK_TOKEN=
+NGROK_HOSTNAME=

--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ ITproject/
    ```bash
    pip install pyngrok python-dotenv
    ```
-2. Creeaza fisierul `.env` cu tokenurile tale, dupa exemplu:
-   ```python
-   with open(".env", "w") as f:
-       f.write("SECRET_KEY=random123\n")
-       f.write("GEMINI_API_KEY=tokenul_tau_aici\n")
-       f.write("NGROK_TOKEN=tokenul_tau_aici\n")
-       f.write("NGROK_HOSTNAME=stable-xxxxx-xxxxx.ngrok-free.app\n")
-   ```
+2. Copiaza fisierul `.env.example` in `.env` si completeaza valorile propriilor tokenuri.
 3. Lanseaza aplicatia folosind scriptul de deploy:
    ```bash
    python deploy.py


### PR DESCRIPTION
## Summary
- add `.env.example` with common variables
- simplify environment setup in README

## Testing
- `python -m py_compile deploy.py`

------
https://chatgpt.com/codex/tasks/task_e_6841471216f48320b03559358f96f4a0