### PR TITLE
Update PDF export comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -725,9 +725,8 @@ class CostCalculator {
 
         setTimeout(() => {
             const clone = element.cloneNode(true);
-            // Let html2canvas handle the Chart.js canvas directly to avoid
-            // cross-origin issues when calling `toDataURL` manually.
-            // The cloned section will contain the original canvas element.
+            // The cloned section retains the Chart.js canvas.
+            // html2canvas (useCORS: true) captures it directly.
 
             const opt = {
                 margin:       10,


### PR DESCRIPTION
## Summary
- remove stale comment referring to `canvas.toDataURL`
- note that html2canvas directly captures the original canvas with `useCORS: true`

## Testing
- `python -m py_compile deploy.py`
- `python -m http.server 8000 &` then `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68414b5791808320b82328e1fb41633d