### PR TITLE
Fix PDF export

### DIFF
--- a/app.js
+++ b/app.js
@@ -720,7 +720,7 @@ class CostCalculator {
             return;
         }
 
-        if (typeof window.html2pdf === 'undefined') {
+        if (typeof window.html2pdf === 'undefined' || window.html2pdf.isStub) {
             this.showMessage('Export PDF indisponibil', 'error');
             return;
         }

--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="lib/html2pdf.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js" onerror="this.onerror=null;this.src='lib/html2pdf.bundle.min.js';"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/lib/html2pdf.bundle.min.js
+++ b/lib/html2pdf.bundle.min.js
@@ -1,2 +1,3 @@
 // Lightweight stub for html2pdf.js used in offline environments
-window.html2pdf=function(){return{set:function(){return this;},from:function(){return this;},save:function(){return Promise.resolve();}}};
+window.html2pdf=function(){return{set:function(){return this;},from:function(){return this;},save:function(){return Promise.reject('html2pdf stub');}}};
+window.html2pdf.isStub=true;


### PR DESCRIPTION
## Summary
- load `html2pdf.js` from CDN with local fallback
- mark local stub and detect it in `exportPDF`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841509bd2a48320aca13b5773d211c0