### PR TITLE
Fix PDF export fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ python -m http.server 8000
 ```
 si apoi deschizi `http://localhost:8000` in browser.
 
+### Export PDF
+Exportul PDF foloseste libraria `html2pdf.js` incarcata de pe CDN. Daca nu exista conexiune la internet, aplicatia va deschide fereastra de printare a browserului. Pentru generarea automata a PDF-ului offline, descarca versiunea originala `html2pdf.bundle.min.js` si inlocuieste fisierul din directorul `lib/`.
+
 ## Exemple vizuale
 
 *(Poti adauga aici capturi de ecran cu interfata aplicatiei.)*

--- a/app.js
+++ b/app.js
@@ -721,7 +721,21 @@ class CostCalculator {
         }
 
         if (typeof window.html2pdf === 'undefined' || window.html2pdf.isStub) {
-            this.showMessage('Export PDF indisponibil', 'error');
+            // Fallback simplu la funcția de printare a browserului atunci când
+            // librăria html2pdf nu este disponibilă (de exemplu, offline).
+            const printContents = element.cloneNode(true);
+            const printWindow = window.open('', '_blank');
+            printWindow.document.write('<html><head><title>Estimare costuri</title>');
+            document.querySelectorAll('link[rel="stylesheet"], style').forEach(s => {
+                printWindow.document.write(s.outerHTML);
+            });
+            printWindow.document.write('</head><body>');
+            printWindow.document.write(printContents.outerHTML);
+            printWindow.document.write('</body></html>');
+            printWindow.document.close();
+            printWindow.focus();
+            printWindow.print();
+            printWindow.close();
             return;
         }
 


### PR DESCRIPTION
## Summary
- fallback to browser print dialog when html2pdf isn't available
- document how to replace the stubbed html2pdf library in README

## Testing
- `python -m py_compile deploy.py`


------
https://chatgpt.com/codex/tasks/task_e_6841537e15708320a03a6bae75b52959