### PR TITLE
Add TXT export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ si apoi deschizi `http://localhost:8000` in browser.
 ### Export PDF
 Exportul PDF foloseste libraria `html2pdf.js` incarcata de pe CDN. Daca nu exista conexiune la internet, aplicatia va deschide fereastra de printare a browserului. Pentru generarea automata a PDF-ului offline, descarca versiunea originala `html2pdf.bundle.min.js` si inlocuieste fisierul din directorul `lib/`.
 
+### Export TXT
+Butonul **Exportă TXT** creează un fișier text cu sumarul ofertului curent (proiect, client și costuri). Fișierul este generat local și poate fi descărcat direct din browser.
+
 ## Exemple vizuale
 
 *(Poti adauga aici capturi de ecran cu interfata aplicatiei.)*

--- a/app.js
+++ b/app.js
@@ -256,6 +256,13 @@ class CostCalculator {
             this.loadFromStorage();
         });
 
+        const exportTxtBtn = document.getElementById('exportTxtBtn');
+        if (exportTxtBtn) {
+            exportTxtBtn.addEventListener('click', () => {
+                this.exportTXT();
+            });
+        }
+
         document.getElementById('navConfig').addEventListener('click', () => {
             document.getElementById('calculatorView').style.display = 'none';
             document.getElementById('configSection').style.display = 'block';
@@ -773,6 +780,38 @@ class CostCalculator {
                 document.body.removeChild(clone);
             }
         }, 300);
+    }
+
+    exportTXT() {
+        this.calculateAll();
+        const typeSelect = document.getElementById('projectType');
+        const typeText = typeSelect.options[typeSelect.selectedIndex].text;
+        const compSelect = document.getElementById('complexity');
+        const compText = compSelect.options[compSelect.selectedIndex].text;
+
+        const lines = [
+            `Proiect: ${document.getElementById('projectName').value}`,
+            `Client: ${document.getElementById('clientName').value}`,
+            `Tip proiect: ${typeText}`,
+            `Complexitate: ${compText}`,
+            '',
+            `Costuri Software: ${document.getElementById('summarySoftware').textContent}`,
+            `Costuri Hardware: ${document.getElementById('summaryHardware').textContent}`,
+            `Subtotal: ${document.getElementById('summarySubtotal').textContent}`,
+            `Buffer Risc: ${document.getElementById('summaryRisk').textContent}`,
+            `Marjă Comercială: ${document.getElementById('summaryMargin').textContent}`,
+            `TOTAL FINAL: ${document.getElementById('summaryTotal').textContent}`
+        ];
+
+        const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'estimare_costuri.txt';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
     }
 
     resetCalculator() {

--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@
                     <button type="button" id="resetBtn" class="btn btn--secondary">Resetează</button>
                     <button type="button" id="saveBtn" class="btn btn--primary">Salvează Estimarea</button>
                     <button type="button" id="loadBtn" class="btn btn--outline">Încarcă Estimarea</button>
+                    <button type="button" id="exportTxtBtn" class="btn btn--outline">Exportă TXT</button>
                 </div>
             </section>
             </div>


### PR DESCRIPTION
## Summary
- add button to export summary to TXT
- handle exportTXT in JS
- document TXT export in README

## Testing
- `python -m py_compile deploy.py`

------
https://chatgpt.com/codex/tasks/task_e_68417de91b588320ac289748681eab71